### PR TITLE
Prevent range selection containing blocked dates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
   dayDisabledText: {
     color: 'gray'
   },
-  daySeletedText: {
+  daySelectedText: {
     color: 'rgb(252, 252, 252)'
   }
 });
@@ -153,7 +153,7 @@ export const Week = (props: WeekType) => {
     const styleText = [
       styles.dayText,
       isDisabled && styles.dayDisabledText,
-      isSelected && styles.daySeletedText
+      isSelected && styles.daySelectedText
     ];
 
     days.push(

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ export const Week = (props: WeekType) => {
           });
         }
         onDatesChange(isPeriodBlocked ?
-          dates(end, null, focusedInput) :
+          dates(end, null, 'startDate') :
           dates(start, end, focusedInput));
       } else {
         onDatesChange({ date: day });

--- a/src/index.js
+++ b/src/index.js
@@ -121,9 +121,17 @@ export const Week = (props: WeekType) => {
   moment.range(startOfWeek, endOfWeek).by('days', (day: moment) => {
     const onPress = () => {
       if (range) {
+        let isPeriodBlocked = false;
         const start = focusedInput === 'startDate' ? day : startDate;
         const end = focusedInput === 'endDate' ? day : endDate;
-        onDatesChange(dates(start, end, focusedInput));
+        if (start && end) {
+          moment.range(start, end).by('days', (dayPeriod: moment) => {
+            if (isDateBlocked(dayPeriod)) isPeriodBlocked = true;
+          });
+        }
+        onDatesChange(isPeriodBlocked ?
+          dates(end, null, focusedInput) :
+          dates(start, end, focusedInput));
       } else {
         onDatesChange({ date: day });
       }


### PR DESCRIPTION
I added a piece of code that is checking, when a start date and an end date is selected, that the period does not match the `isDateBlocked()` on one or more days.
If the period contains blocked dates, it'll set the startDate as the last focused date.

Tell me if you see something wrong in terms of code style/logic.